### PR TITLE
ci: use latest Python 3 for labels workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.x
       - name: Install labels
         run: pip install labels
       - name: Sync config with Github


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos